### PR TITLE
Fix Firefox bug

### DIFF
--- a/lib/pelias/server/static/javascript/application.js
+++ b/lib/pelias/server/static/javascript/application.js
@@ -70,15 +70,15 @@ angular.module('play').service('SearchService', ['$http', function ($http) {
   return {
 
     search: function (host, query, callback) {
-      $http({ method: 'GET', url: host + '/search', params: { query: query } }).success(callback);
+      $http({ method: 'GET', url: host + 'search', params: { query: query } }).success(callback);
     },
 
     suggest: function (host, query, callback) {
-      $http({ method: 'GET', url: host + '/suggest', params: { query: query } }).success(callback);
+      $http({ method: 'GET', url: host + 'suggest', params: { query: query } }).success(callback);
     },
 
     reverse: function (host, lng, lat, callback) {
-      $http({ method: 'GET', url: host + '/reverse', params: { lng: lng, lat: lat } }).success(callback);
+      $http({ method: 'GET', url: host + 'reverse', params: { lng: lng, lat: lat } }).success(callback);
     }
 
   };


### PR DESCRIPTION
Changed default host in demo app to avoid "Blocked loading mixed active content" errors on Firefox 23+

Someone pointed out that the current Pelias demo doesn't work on newer versions of Firefox at SOTM-EU.

This is due to 'Mixed active content' warnings; basically the same thing MS Exploder used to do; when the page is served via `HTTPS` and some content is `HTTP` then it silently fails.

I think this patch should fix the issue although I didn't test it, can someone please do a quick code review, merge & release?
