### PR TITLE
Add contribution section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,18 @@ number of Node packages, each with its own repository under the [Pelias GitHub
 organization](https://github.com/pelias). ElasticSearch is our unconventional datastore of choice because of its
 unparalleled text functionality, which makes text search *just work* right out of the box, and sufficiently robust
 geospatial support.
+
+### Contributing
+
+We built Pelias as an open source project not just because we believe that users should be able to view and play with
+the source code of tools they use, but to get the community involved in the project itself.
+
+Anything that we can do to make contributing easier, we want to know about.  Feel free to reach out to us via Github,
+[Gitter](https://gitter.im/pelias/api), or Twitter. We'd love to help people get started working on Pelias, especially
+if you're new to open source or programming in general. Both this [meta-repo](https://github.com/pelias/pelias/issues)
+and the [API repo](https://github.com/pelias/api/issues) are good places to get started looking for tasks to tackle. We
+also welcome reporting issues or suggesting improvements to our [documentation](https://github.com/pelias/pelias-doc).
+
+The Pelias team can be found on Github as [dianashk](https://github.com/dianashk),
+[missinglink](https://github.com/missinglink), [orangejulius](https://github.com/orangejulius),
+[riordan](https://github.com/riordan), and [stephenkhess](https://github.com/stephenkhess).


### PR DESCRIPTION
I was watching the [CodeNewbies](https://twitter.com/CodeNewbies)
Twitter chat on open sorce contributions last night. They had some great
discussion on how to help people get involved:

* having a contributing section in the readme
* listing team members who can help in that readme [#](https://twitter.com/mohnishgj/status/649398042395701248)
* tagging issues as low-hanging-fruit or starter tasks[#](https://twitter.com/bytemeorg/status/649399390914764801)
* promoting contributions to docs [#](https://twitter.com/Transition/status/649399754904899584) [#](https://twitter.com/Transition/status/649399518048313345)
* having good docs :) [#](https://twitter.com/cliftonC76/status/649398202756657152)
* having unit tests (i think we have this one covered, especially with @stevenkhess around now) [#](https://twitter.com/cliftonC76/status/649398334843711489)

So here's a little contribution section that hopefully helps us along
with that.