### PR TITLE
Use pelias/pelias Gitter Chat

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ We built Pelias as an open source project not just because we believe that users
 the source code of tools they use, but to get the community involved in the project itself.
 
 Anything that we can do to make contributing easier, we want to know about.  Feel free to reach out to us via Github,
-[Gitter](https://gitter.im/pelias/api), or Twitter. We'd love to help people get started working on Pelias, especially
+[Gitter](https://gitter.im/pelias/pelias), or Twitter. We'd love to help people get started working on Pelias, especially
 if you're new to open source or programming in general. Both this [meta-repo](https://github.com/pelias/pelias/issues)
 and the [API repo](https://github.com/pelias/api/issues) are good places to get started looking for tasks to tackle. We
 also welcome reporting issues or suggesting improvements to our [documentation](https://github.com/pelias/pelias-doc).


### PR DESCRIPTION
As part of #138, it seems like we want to settle one one chat room, and while pelias/api has historically been the active one, pelias/pelias should probably be the main one going forward