### PR TITLE
Fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,10 @@ Reverse geocoding is the opposite: returning a list of places near a given point
 ### Developer Documentation & API Access
 
 Sure! Our API lives at [search.mapzen.com](http://search.mapzen.com/), and is usable with an API key ([register here](https://mapzen.com/developers)) and generous
-rate-limits. The endpoints are documented [here](https://github.com/pelias/pelias-doc/blob/master/index.md); happy
+rate-limits. The endpoints are documented [here](https://mapzen.com/documentation/search); happy
 geocoding!
 
-[The Mapzen Search documentation](https://github.com/pelias/pelias-doc/blob/master/index.md) also applies to standalone versions of Pelias, leaving aside API keys, privacy flags, and data sources which may be configured differently for other installations.
+[The Mapzen Search documentation](https://mapzen.com/documentation/search) also applies to standalone versions of Pelias, leaving aside API keys, privacy flags, and data sources which may be configured differently for other installations.
 
 ```javascript
 $ curl -s "search.mapzen.com/v1/reverse?size=1&point.lat=40.74358294846026&point.lon=-73.99047374725342&api_key={YOUR_API_KEY}" | json


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
There is a broken link to our documentation repo.
Fixes #407

---
#### Here's what actually got changed :clap:
Updated the link in 2 places to point to the mapzen.com/documetation site instead.

---
#### Here's how others can test the changes :eyes:
Click the links in the README.md in the following sentences:

`The endpoints are documented here; happy geocoding!`
`The Mapzen Search documentation also applies to standalone versions of Pelias...`