### PR TITLE
Fixes link to data-sources.md in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,7 +36,7 @@ In general, Pelias will require:
 ## Choose your datasets
 
 Pelias can currently import data from four different sources. The contents and description of these
-sources are available on our [data sources page](./data-sources.md). Here we'll just focus on what to
+sources are available on our [data sources page](https://github.com/pelias/pelias-doc/blob/master/data-sources.md). Here we'll just focus on what to
 download for each one.
 
 ### Who's on First


### PR DESCRIPTION
The link to the data-sources.md file in INSTALL.md was pointing to the local repo, but the file seems to have been moved to pelias-doc.  This PR updates the link in INSTALL.md to point to the correct file in the correct repo.

---
#### Here's the reason for this change :rocket:
Fixes Link to Data Sources Documentation

---
#### Here's what actually got changed :clap:
The target of the "data-sources" link in the install doc.

---
#### Here's how others can test the changes :eyes:
Open INSTALL.md and click the "data sources page" link under the heading "Choose your datasets"
