### PR TITLE
Highlighted prerequisites, new section for PiP and Interpolation services

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -36,7 +36,10 @@ Once you checked that [system requirements](#system-requirements) are met, these
 7. [Install the libpostal text analyzer (recommended)](#install-libpostal-optional-but-recommended)
     1. See Libpostal [installation docs](https://github.com/openvenues/libpostal#installation)
     2. Install node modules for Pelias API `$ cd api; npm install`
-8. [Start the API server to begin handling queries](#start-the-api)
+8. [Install and start additional services (recommended)](#install-point-in-polygon-service-and-interpolation-optional-but-recommended)
+    * [pipService](https://github.com/pelias/pip-service#installation)
+    * [interpolation](https://github.com/pelias/interpolation)
+9. [Start the API server to begin handling queries](#start-the-api)
     1. Thanks to `~/pelias.json`, the API is ready for [queries](#geocode-with-Pelias) with `npm start`!
 
 ## System Requirements
@@ -422,6 +425,47 @@ We’re going to move towards hardening our dependency on libpostal by officiall
 Once configured, the API will use libpostal via the [node-postal](https://github.com/openvenues/node-postal)
 NPM module.
 
+### Install Point-in-Polygon Service and Interpolation (optional, but recommended)
+
+Two additional services improve the accuracy of the search results: Point-in-Polygon and Interpolation.
+
+ The [Admin Lookup](#admin-lookup-city-state-etc-information-on-addressesvenues) process relies [Point-in-Polygon (PiP) Service](https://github.com/pelias/pip-service) to fill in incomplete records with the admin hierarchy information from Who's on First. PiP Service looks up whether a point, such as an housenumber and street name with lat-lon coordinates, is inside, outside, or on the boundary of a polygon. This polygon, a closed area, can be a city, state, or any admin region.
+
+Install the node modules for PiP Service in the API repository. Note that PiP Service requires [Who's on First](#whos-on-first) admin hierarchy data. Configure the Pelias API to use Point-in-Polygon by adding a section like this to `pelias.json` under `"api"`.
+```bash
+{
+	"api": {
+		"services": {
+			"pip": {
+				"url": "http://localhost:3102"
+			}
+	}
+}
+```
+PiP service requires Who's on First admin hierarchy data. Start and keep PiP service running.
+```bash
+cd pip-service
+npm start /path/to/whosonfirstdata 						#assumes you have downloaded WOF data
+```
+
+[Interpolation](https://github.com/pelias/interpolation) is a tool to "fill in the gaps" for streets where house numbers are missing. This step is a [fallback option](#how-searching-works-internally) when the exact address cannot be matched. Interpolation can estimate where the point may be given other house numbers on the street.
+
+The [installation document](https://github.com/pelias/interpolation#workflow) has details on the databases to build. Note that Interpolation requires [Polylines](#street-data-polylines) data. Configure the Pelias API to use Interpolation by adding a section like this to `pelias.json`.
+```bash
+{
+	"interpolation": {
+    "client": {
+      "adapter": "http",
+      "host": "http://localhost:3000"
+    }
+  },
+}
+```
+With the databases created, you can start running Interpolation.
+```bash
+cd interpolation
+./interpolate server address.db street.db
+```
 
 ### Start the API
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -343,7 +343,7 @@ Two additional services improve the accuracy of the search results: Point-in-Pol
 #### Point in Polygon (PiP)
 [Point-in-Polygon (PiP) Service](https://github.com/pelias/pip-service) is used for accurate reverse geocoding queries. Given the latitude and longitude coordinates, PiP Service looks up whether the point is inside, outside, or on the boundary of a neighborhood, city, country, etc depending on granularity.
 
-Install the node modules for PiP Service in the API repository. Note that PiP Service requires [Who's on First](#whos-on-first) admin hierarchy data. Configure the Pelias API to use Point-in-Polygon by adding a section like this to `pelias.json` under `"api"`.
+Note that PiP Service requires [Who's on First](#whos-on-first) admin hierarchy data. Configure the Pelias API to use Point-in-Polygon by adding a section like this to `pelias.json` under `"api"`.
 ```bash
 {
 	"api": {

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,6 +22,7 @@ These are the steps for fully installing Pelias:
 1. [Set up PiP Service and Interpolation (recommended)](#install-point-in-polygon-service-and-interpolation-optional-but-recommended)
 1. [Start the API server to begin handling queries](#start-the-api)
 
+
 ## System Requirements
 In general, Pelias will require:
 
@@ -151,6 +152,7 @@ At a minimum, you'll need
 1. [Pelias schema](https://github.com/pelias/schema/)
 2. [API](https://github.com/pelias/api/)
 3. Importer(s)
+
 
 Here's a bash snippet that will download all the repositories (they are all small enough that you don't
 have to worry about the space of the code itself), check out the production branch (which is
@@ -423,4 +425,4 @@ user.
 our best guess of where the address might be. This is the same street (and its centroid) that we
 found in step 2.
 You need polylines in order to get street centroids and interpolation in your results. Without those,
-you’re relying purely on the data being present in OpenAddressesA or OpenStreetMap as a point.
+you’re relying purely on the data being present in OpenAddresses or OpenStreetMap as a point.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -333,6 +333,9 @@ data represents a statistical natural language processing model of address parsi
 OpenStreetMap data. The API will also require about 4GB of memory (it used only a few hundred
 before), to store the needed data for queries.
 
+Install libpostal following its [installation docs](https://github.com/openvenues/libpostal#installation).
+This will also download the training data, so be sure to have enough free disk space.
+
 ### Install Point-in-Polygon Service and Interpolation (optional, but recommended)
 
 Two additional services improve the accuracy of the search results: Point-in-Polygon and Interpolation.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,6 +1,6 @@
 # Installing Pelias
 
-These instructions will help you set up the Pelias geocoder from scratch. It assumes some knowlege
+These instructions will help you set up the Pelias geocoder from scratch. It assumes some knowledge
 of the command line and Node.js, but we'd like as many people as possible to be able to install
 Pelias, so if anything is confusing, please don't hesitate to reach out. We'll do what we can to
 help and also improve the documentation.
@@ -12,20 +12,32 @@ your setup to a reference. All information on Mapzen Search can be found
 
 ## Installation Overview
 
-The steps for fully installing Pelias:
-1. [Decide which datasets](#choose-your-datasets) and [settings](choose-your-import-settings) will be used. Download appropriate data from each external sources
-	1. Who's on First
-	2. Geonames
-	3. OpenAddresses
-	4. OpenStreetMap
-		1. Street Data (Polylines)
+Once you checked that [system requirements](#system-requirements) are met, these are the steps for fully installing Pelias:
+
+1. Decide which [datasets](#choose-your-datasets) and [settings](#choose-your-import-settings) will be used. Download appropriate data from each source.
+	* [Who's on First](https://github.com/pelias/whosonfirst#downloading-the-data) (including admin lookup)
+	* [Geonames](https://github.com/pelias/geonames/#installation)
+	* [OpenAddresses](https://results.openaddresses.io/)
+	* [OpenStreetMap](https://mapzen.com/data/metro-extracts/)
+		* [Street Data (Polylines)](https://github.com/pelias/polylines#download-data)
 2. [Download Pelias code, using the appropriate branches](#choose-your-pelias-code-branch)
+    1. Download these repositories: [Pelias Schema](https://github.com/pelias/schema), [API](https://github.com/pelias/api), and importer(s) ([Who's on First](https://github.com/pelias/whosonfirst), [Geonames](https://github.com/pelias/geonames), [OpenAddresses](https://github.com/pelias/openaddresses), [OpenStreetMap](https://github.com/pelias/openstreetmap)) corresponding to downloaded data source
+    2. Git checkout the production branch (recommended) and install all node module dependencies
 3. [Customize Pelias Configuration file](#customize-pelias-config)
-4. [Set up Elasticsearch](#elasticsearch-configuration)
+    1. Create configuration file `~/pelias.json` (recommended placing in home directory). For the default settings, see the [default config file](https://github.com/pelias/config/blob/master/config/defaults.json)
+    2. Specify the absolute path to the data files under `"imports"`. If needed, change the port for Elasticsearch (default: 9200) and number of shards (default: 5)
+4. [Set up Elasticsearch](#install-elasticsearch)
+    1. Download Elasticsearch [2.3.0](https://www.elastic.co/downloads/past-releases/elasticsearch-2-3-0)
 5. [Install the Elasticsearch schema using pelias-schema](#set-up-the-elasticsearch-schema)
+    1. Apply the Pelias schema `$ cd schema; node scripts/create_index.js`
 6. [Use one or more importers to load data into Elasticsearch](#run-the-importers)
+    1. Run Elasticsearch `$ cd elasticsearch; bin/elasticsearch `
+    2. Load data for each importer `$ cd ${importer}; npm start`
 7. [Install the libpostal text analyzer (recommended)](#install-libpostal-optional-but-recommended)
+    1. See Libpostal [installation docs](https://github.com/openvenues/libpostal#installation)
+    2. Install node modules for Pelias API `$ cd api; npm install`
 8. [Start the API server to begin handling queries](#start-the-api)
+    1. Thanks to `~/pelias.json`, the API is ready for [queries](#geocode-with-Pelias) with `npm start`!
 
 ## System Requirements
 
@@ -43,16 +55,16 @@ All internal Mapzen development of Pelias is done on Linux and macOS so we stron
 
 ## Choose your datasets
 
-Pelias can currently import data from four different sources, using five different importers. The contents and description of these 
+Pelias can currently import data from four different sources, using five different importers. The contents and description of these
 sources are available on our [data sources page](https://mapzen.com/documentation/search/data-sources/).
-Here we'll just focus on what to download for each one. 
+Here we'll just focus on what to download for each one.
 
 We recommend creating a `/Data` folder with subfolders to store datasets from each source. (For example, `Data/whosonfirst` can hold data from Who's on First.)
 
 ### Who's on First
 
 The [Who's on First](https://github.com/pelias/whosonfirst#downloading-the-data) importer can download all the Who's
-on First data quickly and easily. You can also just download hierarchy information, which [admin lookup ](#admin-lookup-city-state-etc-information-on-addressesvenues) (city, state, etc information on addresses/venues) depends on. See the README for the most up to date instructions.
+on First data quickly and easily. There is an option to download just the hierarchy information, which [admin lookup ](#admin-lookup-city-state-etc-information-on-addressesvenues) (city, state, etc information on addresses/venues) depends on. See the README for the most up to date instructions.
 
 ### Geonames
 
@@ -108,7 +120,7 @@ admin lookup are up to 10 times slower than without.
 
 Who's on First, of course, always includes full hierarchy information because it's built into the
 dataset itself, so there's no tradeoff to be made. Who's on First data will always import quite fast
-and with full hierarchy information. 
+and with full hierarchy information.
 
 ### Address Deduplication
 
@@ -196,10 +208,10 @@ development of new features.
 
 ### Download the Pelias repositories
 
-At a minimum, you'll need 
-1. Pelias [schema](https://github.com/pelias/schema/) 
-2. [api](https://github.com/pelias/api/) repositories
-3. at least one of the importers. 
+At a minimum, you'll need
+1. [Pelias schema](https://github.com/pelias/schema/)
+2. [API](https://github.com/pelias/api/)
+3. Importer(s)
 
 Here's a bash snippet that will download all the repositories (they are all small enough that you don't
 have to worry about the space of the code itself), check out the production branch (which is
@@ -247,7 +259,7 @@ config is sent along to the [elasticsearch-js](https://github.com/elastic/elasti
 any of its [configuration options](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/configuration.html)
 are valid.
 
-#### Where to find the downloaded data files.
+#### Where to find the downloaded data files
 The other major section, `imports`, defines settings for each importer.  `adminLookup` has it's own section and its value applies to all importers. The defaults look like this:
 
 ```json
@@ -330,7 +342,7 @@ _Note:_ The schema scripts also check for required Elasticsearch plugins, and wi
 install them if not present.
 
 ```bash
-cd schema                      # assuming you've just run the bash snippet to download the repos from earlier
+cd schema                      # assuming you have just run the bash snippet to download the repos from earlier
 node scripts/create_index.js
 ```
 
@@ -374,7 +386,7 @@ expect around 800-2000 inserts per second.
 The order of imports do not matter. Multiple importers can be run in parallel to speed up the setup process.
 Each of our importers operates independent of the data that is already in Elasticsearch.
 So you can, for example, import OSM data without first having imported WOF data.
-However, when turning on admin lookup, the WOF data must be on disk, as it's used during the 
+However, when turning on admin lookup, the WOF data must be on disk, as it is used during the
 import process to enrich the data with admin information.
 WOF data does not need to be imported for the admin lookup to work.
 
@@ -394,7 +406,7 @@ before), to store the needed data for queries.
 First, install libpostal following its [installation docs](https://github.com/openvenues/libpostal#installation).
 This will also download the training data, so be sure to have enough free disk space.
 
-Next, configure the Pelias API to use libpostal (it won't by default) by adding a section like this
+Next, configure the Pelias API to use libpostal (it would not by default) by adding a section like this
 to `pelias.json`:
 
 ```json
@@ -410,12 +422,13 @@ We’re going to move towards hardening our dependency on libpostal by officiall
 Once configured, the API will use libpostal via the [node-postal](https://github.com/openvenues/node-postal)
 NPM module.
 
+
 ### Start the API
 
 As soon as you have any data in Elasticsearch, you can start running queries against the
 [Pelias API server](https://github.com/pelias/api/). If you installed Libpostal, reinstall the API node modules so that API connects to the text analyzer.
 
-Again thanks to `pelias.json`, the API already knows how to connect to Elasticsearch, so all that's
+Again thanks to `pelias.json`, the API already knows how to connect to Elasticsearch, so all that is
 required to start the API is `npm start`. You can now send queries to Pelias!
 
 
@@ -439,22 +452,22 @@ For information on the Pelias endpoints and their parameters, see the [Mapzen Se
 
 ### How searching works internally
 
-1. When we search for an address, we first attempt to find it in the address index in Elasticsearch 
-and if an exact match is found all is well and we simply send that back as a result. In this case, 
+1. When we search for an address, we first attempt to find it in the address index in `Elasticsearch`
+. If an exact match is found all is well and we simply send that back as a result. In this case,
 the more addresses we have in the index the better the results will be.
-2. If for some reason we weren’t able to locate that address in the Elasticsearch address layer, 
-we will attempt to find just the street (without the house number) in the Elasticsearch street layer. 
-This is where the polylines import becomes important. If you choose to not import the polylines data, 
+2. If, for some reason, we weren’t able to locate that address in the Elasticsearch address layer,
+we will attempt to find just the street (without the house number) in the Elasticsearch street layer.
+This is where the `polylines` import becomes important. If you choose to not import the polylines data,
 you won’t have this backup option when an address is not found in the first step.
-3. If the street was found successfully we use that street to attempt address interpolation, which is 
-the process of estimating where a housenumber would reside along the street given other housenumbers 
-on that street. For this step to be performed you must have an instance of the interpolation service 
-up and running and the API must be made aware of it via pelias-config. If an address can be 
-interpolated given the street and expected housenumber, we will send that approximated result to the 
+3. If the street was found successfully we use that street to attempt address interpolation, which is
+the process of estimating where a housenumber would reside along the street given other housenumbers
+on that street. For this step to be performed you must have an instance of the `interpolation` service
+up and running and the API must be made aware of it via pelias-config. If an address can be
+interpolated given the street and expected housenumber, we will send that approximated result to the
 user.
-4. If the interpolation service is not able to help further, we will send back the street centroid as 
-our best guess of where the address might be. This is the same street (and its centroid) that we 
+4. If the interpolation service is not able to help further, we will send back the street centroid as
+our best guess of where the address might be. This is the same street (and its centroid) that we
 found in step 2.
 
-You need polylines in order to get street centroids and interpolation in your results. without those 
+You need polylines in order to get street centroids and interpolation in your results. without those
 you’re relying purely on the data being present in OA or OSM as a point.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,23 +12,27 @@ your setup to a reference. All information on Mapzen Search can be found
 
 ## Installation Overview
 
-The steps for fully installing Pelias look like this:
-
-1. Decide which datasets and settings will be used
-2. Download appropriate data
-3. Download Pelias code, using the appropriate branches
-4. Set up Elasticsearch
-5. Install the Elasticsearch schema using pelias-schema
-6. Use one or more importers to load data into Elasticsearch
-7. Install the libpostal text analyzer (recommended)
-8. Start the API server to begin handling queries
+The steps for fully installing Pelias:
+1. [Decide which datasets](#choose-your-datasets) and [settings](choose-your-import-settings) will be used. Download appropriate data from each external sources
+	1. Who's on First
+	2. Geonames
+	3. OpenAddresses
+	4. OpenStreetMap
+		1. Street Data (Polylines)
+2. [Download Pelias code, using the appropriate branches](#choose-your-pelias-code-branch)
+3. [Customize Pelias Configuration file](#customize-pelias-config)
+4. [Set up Elasticsearch](#elasticsearch-configuration)
+5. [Install the Elasticsearch schema using pelias-schema](#set-up-the-elasticsearch-schema)
+6. [Use one or more importers to load data into Elasticsearch](#run-the-importers)
+7. [Install the libpostal text analyzer (recommended)](#install-libpostal-optional-but-recommended)
+8. [Start the API server to begin handling queries](#start-the-api)
 
 ## System Requirements
 
 In general, Pelias will require:
 
-* A working [Elasticsearch](https://www.elastic.co/products/elasticsearch) 2.3 cluster. It can be on
-  a single machine or across several
+* A working [Elasticsearch](https://www.elastic.co/downloads/past-releases/elasticsearch-2-3-0) 2.3 cluster. It can be on
+  a single machine or across several. This is currently the only version Pelias supports.
 * [Node.js](https://nodejs.org/) 4.0 or newer (the latest in the Node 4 or 6 series is recommended). Node.js 0.10 and 0.12 are no longer supported
 * At a minimum 100GB disk space to download, extract, and process data
 * Lots of RAM, 8GB is a good minimum for a small import like a single city. A full North America OSM import just fits in 16GB RAM
@@ -39,14 +43,16 @@ All internal Mapzen development of Pelias is done on Linux and macOS so we stron
 
 ## Choose your datasets
 
-Pelias can currently import data from four different sources, using five different importers. The contents and description of these
+Pelias can currently import data from four different sources, using five different importers. The contents and description of these 
 sources are available on our [data sources page](https://mapzen.com/documentation/search/data-sources/).
-Here we'll just focus on what to download for each one.
+Here we'll just focus on what to download for each one. 
+
+We recommend creating a `/Data` folder with subfolders to store datasets from each source. (For example, `Data/whosonfirst` can hold data from Who's on First.)
 
 ### Who's on First
 
-The [Who's on First](https://github.com/pelias/whosonfirst#data) importer can download all the Who's
-on First data quickly and easily. See the README for the most up to date instructions.
+The [Who's on First](https://github.com/pelias/whosonfirst#downloading-the-data) importer can download all the Who's
+on First data quickly and easily. You can also just download hierarchy information, which [admin lookup ](#admin-lookup-city-state-etc-information-on-addressesvenues) (city, state, etc information on addresses/venues) depends on. See the README for the most up to date instructions.
 
 ### Geonames
 
@@ -102,7 +108,7 @@ admin lookup are up to 10 times slower than without.
 
 Who's on First, of course, always includes full hierarchy information because it's built into the
 dataset itself, so there's no tradeoff to be made. Who's on First data will always import quite fast
-and with full hierarchy information.
+and with full hierarchy information. 
 
 ### Address Deduplication
 
@@ -190,9 +196,12 @@ development of new features.
 
 ### Download the Pelias repositories
 
-At a minimum, you'll need the Pelias [schema](https://github.com/pelias/schema/) and
-[api](https://github.com/pelias/api/) repositories, as well as at least one of the importers. Here's
-a bash snippet that will download all the repositories (they are all small enough that you don't
+At a minimum, you'll need 
+1. Pelias [schema](https://github.com/pelias/schema/) 
+2. [api](https://github.com/pelias/api/) repositories
+3. at least one of the importers. 
+
+Here's a bash snippet that will download all the repositories (they are all small enough that you don't
 have to worry about the space of the code itself), check out the production branch (which is
 probably the one you want), and install all the node module dependencies.
 
@@ -212,8 +221,7 @@ Nearly all configuration for Pelias is driven through a single config file: `pel
 default, Pelias will look for this file in your home directory, but you can configure where it
 looks. For more details, see the [pelias-config](https://github.com/pelias/config) repository.
 
-The two main things of note to configure are where on the network to find Elasticsearch, and where
-to find the downloaded data files.
+#### Where on the network to find Elasticsearch
 
 Pelias will by default look for Elasticsearch on `localhost` at port 9200 (the standard
 Elasticsearch port).
@@ -239,6 +247,7 @@ config is sent along to the [elasticsearch-js](https://github.com/elastic/elasti
 any of its [configuration options](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/configuration.html)
 are valid.
 
+#### Where to find the downloaded data files.
 The other major section, `imports`, defines settings for each importer.  `adminLookup` has it's own section and its value applies to all importers. The defaults look like this:
 
 ```json
@@ -268,6 +277,7 @@ The other major section, `imports`, defines settings for each importer.  `adminL
 }
 ```
 
+Note: The datapath must be an _absolute path._
 As you can see, the default datapaths are meant to be changed.
 
 ### Elasticsearch Configuration
@@ -297,7 +307,7 @@ Pelias, so please refer to the [official 2.3 install docs](https://www.elastic.c
 Older versions of Elasticsearch are not supported.
 
 Make sure Elasticsearch is running and connectable, and then you can continue with the Pelias
-specific setup and importing. Using a plugin like [head](https://mobz.github.io/elasticsearch-head/)
+specific setup and importing. Using a plugin like [Sense](https://github.com/bleskes/sense) [(Chrome extension)](https://chrome.google.com/webstore/detail/sense-beta/lhjgkmllcaadmopgmanpapmpjgmfcfig?hl=en), [head](https://mobz.github.io/elasticsearch-head/)
 or [Marvel](https://www.elastic.co/products/marvel) can help monitor Elasticsearch as you import
 data.
 
@@ -335,6 +345,12 @@ node scripts/create_index.js
 
 _Note_: Elasticsearch has no analogy to a database migration, so you generally have to delete and
 reindex all your data after making schema changes.
+
+Get Elasticsearch running to be ready for imports.
+```bash
+cd elasticsearch
+bin/elasticsearch
+```
 
 ### Run the importers
 
@@ -397,7 +413,7 @@ NPM module.
 ### Start the API
 
 As soon as you have any data in Elasticsearch, you can start running queries against the
-[Pelias API server](https://github.com/pelias/api/).
+[Pelias API server](https://github.com/pelias/api/). If you installed Libpostal, reinstall the API node modules so that API connects to the text analyzer.
 
 Again thanks to `pelias.json`, the API already knows how to connect to Elasticsearch, so all that's
 required to start the API is `npm start`. You can now send queries to Pelias!

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -84,7 +84,7 @@ derived from the OSM planet file.
 
 As may be evident from the dataset section above, importing all the data in all five supported datasets is
 worthy of its own discussion. Current [full planet builds](https://pelias-dashboard.mapzen.com/pelias)
-weigh in at over 340 million documents, and require about 230GB total storage in Elasticsearch.
+weigh in at over 450 million documents, and require about 330GB total storage in Elasticsearch.
 Needless to say, a full planet build is not likely to succeed on most personal computers.
 
 Fortunately, because of services like AWS and the scalability of Elasticsearch, full planet builds


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
I highlighted services/data that were prerequisites for other parts to work (such as who's on first admin hierarchy data for admin lookup). Also, I added links at the top to reference later sections in the page or git repos because the doc is long. 

Included a section on installing point-in-polygon service and interpolation. Those are more services that make search queries return better results.

---
#### Here's what actually got changed :clap:
- [x] Deleted section "Choose your import settings" because admin-lookup is on by default and deduplication is off 
- [x] Linked each step of the installation process to the corresponding page section
- [x] Added section on how to install PiP Service and Interpolation
- [x] Changed Elasticsearch link to go directly to downloading v 2.3.0 rather than ES home page
- [x] Fixed small typos and shortened wording
- [x] Require Libpostal instead of leaving it as optional

---
#### Here's how others can test the changes :eyes:
<!-- this could be queries or just mentioning that you've written unit/end-to-end tests as part of this awesome work... -->
<!-- did we mention, test are amazing! :rainbow: -->
