### PR TITLE
Pelias update

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Gitter](https://badges.gitter.im/pelias/pelias.svg)](https://gitter.im/pelias/pelias?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
-Pelias is the project used to power [Mapzen Search](https://mapzen.com/projects/search)
+**News:** See our [update](./announcements/2018-01-02-pelias-update.md) regarding the Mapzen shutdown.
 
 ### What's a geocoder do anyway?
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Gitter](https://badges.gitter.im/pelias/pelias.svg)](https://gitter.im/pelias/pelias?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 
-**News:** See our [update](./announcements/2018-01-02-pelias-update.md) regarding the Mapzen shutdown.
+**News:** See our [update](https://github.com/pelias/pelias/blob/announcements/2018-01-02-pelias-update.md) regarding the Mapzen shutdown.
 
 ### What's a geocoder do anyway?
 

--- a/announcements/2018-01-02-pelias-update.md
+++ b/announcements/2018-01-02-pelias-update.md
@@ -1,0 +1,31 @@
+Yesterday Mapzen [announced](https://mapzen.com/blog/shutdown/) it will be shutting down at the end of January 2018. As the maintainers of the Pelias project (and, until now, employees of Mapzen), we want to give an update on the Pelias project and Mapzen Search.
+
+# Pelias Open-Source Project
+
+Obviously, there will be changes, but the Pelias project will _not_ be shutting down or going away!
+
+We will be continuing on as a community-run open source project for the immediate future. We're looking into sponsorship options to continue full-time work, and would appreciate if anyone who can help would reach out to us.
+
+Furthermore, while the Pelias project previously had little identity outside of Mapzen, we are looking to change this. In the future, we want to adopt an open governance model that won't tie us to a single entity. Again, if you can help with this, we'd love to hear from you.
+
+All our code on [Github](https://github.com/pelias) will remain. Our infrastructure like [pelias.io](http://pelias.io/), our NPM modules, and [Docker images](https://github.com/pelias/dockerfiles) will also continue to work. There may be some brief downtime on [pelias.io](http://pelias.io) as we migrate things around, but it shouldn't last too long.
+
+Another point of good news is that [Who's on First](https://www.whosonfirst.org/blog/2018/01/02/chapter-two/), an essential data source for Pelias, will also continue on. Many of the URLs for that project will change, and we would love help tracking down anything that breaks as a result. Please submit an issue or pull request if you have the time.
+
+## Mapzen Search
+Mapzen Search, however, will be going away. While this doesn't affect Pelias directly, it was very useful to have a full-planet instance of Pelias to look to for testing and as a baseline example.
+
+The Mapzen [migration guide](https://mapzen.com/blog/migration/) has some suggestions for current users of Mapzen Search.
+
+Current Mapzen Search users who would like to keep using Pelias, **please reach out to us**. It is _possible_ that we will be able to set up a hosted instance of Pelias to replace Mapzen Search if there is enough interest.
+
+The Pelias team is also available for consulting work to help teams set up their own instance of Pelias. This not only provide an alternative to Mapzen Search that does not rely on an external hosted service, but also help to fund continued development of Pelias.
+
+
+## Contact info
+
+As before, for general Pelias questions don't hesitate to reach out on [Gitter](https://gitter.im/pelias/home).
+
+For anyone looking with help migrating away from Mapzen Search, please reach out to our team directly via email: pelias.team@gmail.com
+
+The Pelias team consists of [Diana](https://github.com/dianashk/), [Peter](https://github.com/missinglink), [Julian](https://github.com/orangejulius), and [Stephen](https://github.com/trescube).


### PR DESCRIPTION
Our update on Pelias after the Mapzen shutdown. The link in README.md should work once this is merged.

Unfortunately I don't think there's no easy way to make the link work both on pelias.io and github.com/pelias/pelias without making it an absolute URL directly to the announcement file. Let me know if there are better ways.