### PR TITLE
local_install: Fix two small typos

### DIFF
--- a/milestones/local_install/README.md
+++ b/milestones/local_install/README.md
@@ -12,9 +12,9 @@ Implement a simple installation process for a small local instance of Pelias des
 
 #### Area
 User must be able to limit the install process to a region by specifying either of the following:
-    - the area's boudning box
+    - the area's bounding box
     - the area's Who's on First ID
-When the installation is limitted in either of the above ways, only the relevant data should be downloaded and used in the build process.
+When the installation is limited in either of the above ways, only the relevant data should be downloaded and used in the build process.
 
 #### Data Sources
 User must be able to limit the install process to only desired data sources. For instance, one should be able to only import OpenAddresses data and avoid all others.


### PR DESCRIPTION
Simple starting commit. Fix up two small typos noticed in the documentation.

---
#### Here's the reason for this change :rocket:
<!-- good place to use the magic github words that connect issues with PRs, like 
  - Fixes pelias/pelias#0000
  - Closes pelias/pelias#0000
  - Connected to pelias/pelias#0000
you can also just use good ol' words to explain what this does -->

---
#### Here's what actually got changed :clap:
boudning -> bounding
limitted -> limited

---
#### Here's how others can test the changes :eyes:
Fix will eventually be seen at http://pelias.io/milestones/local_install/index.html 
