### PR TITLE
Update to current Pelias contact email address

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -49,7 +49,7 @@ characteristics above, including participants with disabilities.
 
 ### Reporting Issues
 
-If you experience or witness unacceptable behavior—or have any other concerns—please report it by contacting us via **pelias@mapzen.com**. All reports will be handled with discretion. In your report please include:
+If you experience or witness unacceptable behavior—or have any other concerns—please report it by contacting us via **pelias.team@gmail.com**. All reports will be handled with discretion. In your report please include:
 
 - Your contact information.
 - Names (real, nicknames, or pseudonyms) of any individuals involved. If there are additional witnesses, please

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ We built Pelias as an open source project not just because we believe that users
 the source code of tools they use, but to get the community involved in the project itself.
 
 Anything that we can do to make contributing easier, we want to know about.  Feel free to reach out to us via Github,
-[Gitter](https://gitter.im/pelias/pelias), [email](mailto:search@mapzen.com), or [Twitter](https://twitter.com/mapzen])
+[Gitter](https://gitter.im/pelias/pelias), [email](mailto:pelias.team@gmail.com), or [Twitter](https://twitter.com/mapzen])
  We'd love to help people get started working on Pelias, especially
 if you're new to open source or programming in general. Both this [meta-repo](https://github.com/pelias/pelias/issues)
 and the [API repo](https://github.com/pelias/api/issues) are good places to get started looking for tasks to tackle.


### PR DESCRIPTION
Per https://github.com/pelias/pelias/tree/master/announcements/2018-01-02-pelias-update replace all @mapzen.com email addresses with the current Pelias contact email address.

grep used to confirm no '@mapzen.com' remain.

---
#### Here's the reason for this change :rocket:

Works towards one of the tasks in https://github.com/pelias/pelias/issues/703 ("sweep through all code for mapzen links and other 404s")

---
#### Here's what actually got changed :clap:

- [x] `CODE_OF_CONDUCT.md`
- [x] `README.md`

---
#### Here's how others can test the changes :eyes:
n/a - Documentation only change.
