### PR TITLE
Update to current upstream Who's On First URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Reverse geocoding is the opposite: returning a list of places near a given point
 - Provide accurate search results
 - Give users query suggestions (typeahead in the search box)
 - Account for location bias (places nearer to you appear higher in the results)
-- Support multiple data sources (the defaults are [OpenStreetMap](http://openstreetmap.org/), [OpenAddresses](http://openaddresses.io), [Geonames](http://geonames.org), and [Who's on First](http://whosonfirst.mapzen.com/))
+- Support multiple data sources (the defaults are [OpenStreetMap](http://openstreetmap.org/), [OpenAddresses](http://openaddresses.io), [Geonames](http://geonames.org), and [Who's on First](https://www.whosonfirst.org/))
 - Flexible software architecture
 - Easy to contribute software patches and features to
 - Easy to set up and configure your own instance

--- a/data_licenses.md
+++ b/data_licenses.md
@@ -36,7 +36,7 @@ Layers:
 - `neighbourhood`
 - `coarse` (alias for simultaneously using all the above)
 
-[Who's on First](https://whosonfirst.mapzen.com) is an open-data directory of worldwide administrative places. Created by Mapzen, it is the primary provider of:
+[Who's on First](https://www.whosonfirst.org/) is an open-data directory of worldwide administrative places. Created by Mapzen, it is the primary provider of:
 
 - Countries
 - Macroregions (for example, England is a Macroregion within the United Kingdom)
@@ -82,7 +82,7 @@ Layers:
 - `neighbourhood`
 - `coarse` (alias for simultaneously using all the above)
 
-[Geonames](http://www.geonames.org/) is an aggregation of many authoritative and non-authoritative datasets. It contains information on everything from country borders to airport names to geographical features. While Geonames does not contain any shape data (such as country borders), it does have a powerful and well defined hierarchy to describe the relationships between different records. This custom hierarchy makes it harder to use in combination with data from other sources, but the Mapzen [Who's On First](http://whosonfirst.mapzen.com/) project will help by providing concordance between Geonames and other datasets.
+[Geonames](http://www.geonames.org/) is an aggregation of many authoritative and non-authoritative datasets. It contains information on everything from country borders to airport names to geographical features. While Geonames does not contain any shape data (such as country borders), it does have a powerful and well defined hierarchy to describe the relationships between different records. This custom hierarchy makes it harder to use in combination with data from other sources, but the Mapzen [Who's On First](https://www.whosonfirst.org/) project will help by providing concordance between Geonames and other datasets.
 
 In the meantime, Geonames still provides a wide variety of useful data that helps augment the other datasets.
 


### PR DESCRIPTION
Note: an explicit non-goal of this commit is to update the link to Who's On First spelunker tool referenced in Lily He's `communication/letter_to_future_interns.md`. This is because the instance of upstream Who's On First at https://www.whosonfirst.org/ does not provide the spelunker tool at the moment.

grep used to confirm no other direct whosonfirst.mapzen.com links remain.

---
#### Here's the reason for this change :rocket:
Works towards one of the tasks in pelias/pelias#703 ("Switch all whosonfirst URLs to https://www.whosonfirst.org/")

---
#### Here's what actually got changed :clap:
- [x] `README.md`
- [x] `data_licenses.md`

---
#### Here's how others can test the changes :eyes:
n/a
