### PR TITLE
Fix announcement link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Reverse geocoding is the opposite: returning a list of places near a given latit
 
 ### Where did Pelias come from?
 
-Pelias was created in 2014 as an early project at [Mapzen](https://mapzen.com). After Mapzen's shutdown in 2017, Pelias is now [independent]((https://github.com/pelias/pelias/tree/master/announcements/2018-01-02-pelias-update/).
+Pelias was created in 2014 as an early project at [Mapzen](https://mapzen.com). After Mapzen's shutdown in 2017, Pelias is now [independent](https://github.com/pelias/pelias/tree/master/announcements/2018-01-02-pelias-update/).
 
 ### How does it work?
 


### PR DESCRIPTION
:wave: I did some awesome work for the Pelias project and would love for everyone to have a look at it and provide feedback.

---
#### Here's the reason for this change :rocket:
Link to announcement was not rendered properly

---
#### Here's what actually got changed :clap:
Removed the double `(`

