### PR TITLE
data_licenses: Update additional links from Mapzen->Pelias

### DIFF
--- a/data_licenses.md
+++ b/data_licenses.md
@@ -16,7 +16,7 @@ Layers:
 
 OpenAddresses is by far the largest dataset by number of records. Even though it only contains address data (as in no building names or other metadata), it's a great resource for global geocoding.
 
-The license for each individual source within OpenAddresses differs. Many of the sources require [attribution](https://mapzen.com/rights/), and many others have a share-alike clause.
+The license for each individual source within OpenAddresses differs. Many of the sources require [attribution](https://pelias.io/data_licenses.html), and many others have a share-alike clause.
 *Note:* Pelias does _not_ currently return license information directly, but the license and attribution requirements for each source within OpenAddresses can be determined from the machine-readable [state.txt](http://results.openaddresses.io/state.txt) file published on the OpenAddresses website.
 
 ## Who's on First


### PR DESCRIPTION
Another small fix for the Mapzen->Pelias changeover. Make it easier for embedders and implementers to correctly cite and attribute the data sources used. 

---
#### Here's the reason for this change :rocket:
  - Connected to pelias/pelias #703 

---
#### Here's what actually got changed :clap:
Link was updated in data_licenses.md

---
#### Here's how others can test the changes :eyes:
n/a
