### PR TITLE
Use HTTPS in git clone instead of SSH

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -160,11 +160,11 @@ probably the one you want), and install all the node module dependencies.
 
 ```bash
 for repository in schema api whosonfirst geonames openaddresses openstreetmap polylines; do
-	git clone git@github.com:pelias/${repository}.git    # clone from Github
-	pushd $repository > /dev/null                        # switch into importer directory
-	git checkout production                              # or remove this line to stay with master
-	npm install                                          # install npm dependencies
-	popd > /dev/null                                     # return to code directory
+	git clone https://github.com/pelias/${repository}.git # clone from Github
+	pushd $repository > /dev/null                         # switch into importer directory
+	git checkout production                               # or remove this line to stay with master
+	npm install                                           # install npm dependencies
+	popd > /dev/null                                      # return to code directory
 done
 ```
 


### PR DESCRIPTION
This way you don't need to configure any credentials (or anything).

#### Here's the reason for this change :rocket:
When I executed the shell script provided in the documentation I wasn't able to clone repositories using SSH.
```
Cloning into 'schema'...
Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```


#### Here's what actually got changed :clap:
I changed git clone command in Installation->Importer(s) section to use HTTPS instead of SSH.


#### Here's how others can test the changes :eyes:
- Create a new instance on AWS
- Execute the provided script
