### PR TITLE
Run static site build preview on all branches and PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,14 @@ script:
   - couscous generate
 jobs:
   include:
+    - stage: build
+      php:
+        - '5.6'
+      script:
+        - curl -OS http://couscous.io/couscous.phar
+        - chmod +x couscous.phar
+        - sudo mv couscous.phar /usr/local/bin/couscous
+        - couscous generate
     - stage: release
       php:
         - '5.6'


### PR DESCRIPTION
A while back, our TravisCI was set up in a way where it deployed the static site. However, Travis was configured so that no jobs ran for branches or pull requests, causing those builds to wait in GitHub on a build that would never come.

This change sets up a simple build of the static site contents to provide some assurances that changes are valid, and ensures its run on all branches and pull requests.

Fixes https://github.com/pelias/pelias/issues/841