### PR TITLE
chore: update contact details

### DIFF
--- a/announcements/2018-01-02-pelias-update/README.md
+++ b/announcements/2018-01-02-pelias-update/README.md
@@ -17,7 +17,7 @@ Mapzen Search will be going away. While this doesn't affect Pelias directly, man
 
 The Mapzen [migration guide](https://mapzen.com/blog/migration/) has some suggestions for current users of Mapzen Search.
 
-In particular, some of the team behind Pelias and Mapzen search have created a new company that will offer hosted geocoding using Pelias! It's called [geocode.earth](https://geocode.earth) and is live and ready to take customers.
+In particular, some of the team behind Pelias and Mapzen search have created a new company that will offer hosted geocoding using Pelias! It's called [Geocode Earth](https://geocode.earth) and is live and ready to take customers.
 
 The Pelias team is also available for consulting work to help teams set up their own instance of Pelias. This not only provide an alternative to Mapzen Search that does not rely on an external hosted service, but also will help fund continued development of Pelias.
 
@@ -26,6 +26,4 @@ The Pelias team is also available for consulting work to help teams set up their
 
 As before, for general Pelias questions don't hesitate to reach out on [Gitter](https://gitter.im/pelias/home).
 
-For anyone looking with help migrating away from Mapzen Search, please reach out to our team directly via email: pelias.team@gmail.com
-
-The Pelias team consists of [Diana](https://github.com/dianashk/), [Peter](https://github.com/missinglink), [Julian](https://github.com/orangejulius), and [Stephen](https://github.com/trescube).
+For anyone looking with help migrating away from Mapzen Search, please reach out to our team directly via email: team@pelias.io


### PR DESCRIPTION
migrating from `pelias.team@gmail.com` -> `team@pelias.io`
I also renamed `geocode.earth` -> `Geocode Earth`.

At the bottom was a line which listed the 'core team' I wasn't quite sure what to do with?
Problem is that the information is out-of-date, in particular listing Diana as a primary point of contact, which hasn't been the case for a couple years now.

I considered changing it to [me, julian, joxit] but that is also wrong in the context of a dated announcement.
So in the end I decided to remove that line, no disrespect to our members emeritus but the info isn't accurate any longer 🤷 