### PR TITLE
README: Update 'good first issues' link

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Anything that we can do to make contributing easier, we want to know about.  Fee
  We'd love to help people get started working on Pelias, especially if you're
  new to open source or programming in general.
 
-We have a list of [Good First Issues](https://github.com/issues?q=is%3Aopen+is%3Aissue+org%3Apelias+archived%3Afalse+label%3A%22good+first+issue%22) for new contributors.
+We have a list of [Good First Issues](https://github.com/search?q=org%3Apelias+label%3A%22good+first+issue%22&type=issues) for new contributors.
 
 Both this [meta-repo](https://github.com/pelias/pelias/issues) and the [API service repo](https://github.com/pelias/api/issues) are worth looking at, as
 they're where most issues live. We also welcome reporting issues or suggesting


### PR DESCRIPTION
#### Here's the reason for this change :rocket:
Small fixup for a broken GitHub good-first-issues hyperlink.