### PR TITLE
website: fix image dimensions, use brand color

### DIFF
--- a/website/css/theme-fixes.css
+++ b/website/css/theme-fixes.css
@@ -218,7 +218,23 @@ img[src="https://raw.githubusercontent.com/pelias/design/master/logo/pelias_gith
   height: 100px !important;
 }
 
+/* remove width: 100% on images */
+@media screen and (max-width: 768px) {
+  img {
+    width: auto !important;
+  }
+}
+
 /* fix missing margin-bottom */
 details {
   margin-bottom: 2rem;
+}
+
+/* brand colors */
+.wy-menu-vertical a:active,
+.wy-side-nav-search,
+.wy-side-nav-search img,
+.wy-nav-top,
+.wy-nav-top img {
+  background-color: #6563CB;
 }


### PR DESCRIPTION
it has long annoyed me that the images are all skewed on the `pelias.io` website when viewed as a mobile user.
this PR fixes the issue.

As a bonus I also changed the primary color to match the [brand palette](https://github.com/pelias/design).

<img width="232" alt="Screenshot 2021-06-15 at 15 39 35" src="https://user-images.githubusercontent.com/738069/122062654-b7665600-ce43-11eb-96a3-5bba160ecd35.png">

<img width="234" alt="Screenshot 2021-06-15 at 15 55 32" src="https://user-images.githubusercontent.com/738069/122065314-f3021f80-ce45-11eb-9a2e-44c554abb96a.png">
