### PR TITLE
Upgrade PHP to 7.4 for Couscous build

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,7 +8,7 @@ jobs:
         os:
           - ubuntu-20.04
         php-version:
-          - 5.6
+          - 7.4
     steps:
       - uses: actions/checkout@v2
       - name: 'Install PHP {{ matrix.php-version }}'
@@ -29,7 +29,7 @@ jobs:
         os:
           - ubuntu-20.04
         php-version:
-          - 5.6
+          - 7.4
     steps:
       - uses: actions/checkout@v2
       - name: 'Install PHP {{ matrix.php-version }}'


### PR DESCRIPTION
The actual deployment of our website content to https://pelias.io has been broken for a while, but it looks like all that's required to fix it is upgrading to a more modern version of PHP. We'll see.