### PR TITLE
CI: update Github Action runner Ubuntu versions to 22.04

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
         php-version:
           - 7.4
     steps:
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
         php-version:
           - 7.4
     steps:


### PR DESCRIPTION
GitHub is deprecating Ubuntu 20 based runners [on April 1](https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/), so we want to be off well before then.

Connects https://github.com/pelias/pelias/issues/951